### PR TITLE
xi-edit

### DIFF
--- a/Lectures/lensing_basics_I.ipynb
+++ b/Lectures/lensing_basics_I.ipynb
@@ -91,9 +91,9 @@
     "\n",
     "The lens equation describes the distortion of a coordinate in the source plane as been seen on the image plane:\n",
     "\n",
-    "$$ \\boldsymbol{\\eta} = \\frac{D_{\\rm S}}{D_{\\rm d}} \\boldsymbol{\\zeta} - D_{\\rm ds}\\hat{\\boldsymbol{\\alpha}}(\\boldsymbol{\\zeta}) $$\n",
+    "$$ \\boldsymbol{\\eta} = \\frac{D_{\\rm S}}{D_{\\rm d}} \\boldsymbol{\\xi} - D_{\\rm ds}\\hat{\\boldsymbol{\\alpha}}(\\boldsymbol{\\xi}) $$\n",
     "\n",
-    "In terms of angular coordinates $\\boldsymbol{\\eta} = D_{\\rm s} \\boldsymbol{\\beta}$ and $\\boldsymbol{\\zeta} = D_{\\rm d}\\boldsymbol{\\theta}$ the mapping results in\n",
+    "In terms of angular coordinates $\\boldsymbol{\\eta} = D_{\\rm s} \\boldsymbol{\\beta}$ and $\\boldsymbol{\\xi} = D_{\\rm d}\\boldsymbol{\\theta}$ the mapping results in\n",
     "\n",
     "$$ \\boldsymbol{\\beta} = \\boldsymbol{\\theta} - \\boldsymbol{\\alpha}(\\boldsymbol{\\theta})$$\n",
     "with\n",
@@ -583,7 +583,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -597,7 +597,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I believe the zeta's in the portion of the derivation above the first plot in lensing_basics_I needs to be xi's instead. 

Some notes outside the content of this pull request: it would be helpful to mention that the thin lens approximation is used in the derivation. Also, it is hard to tell that some letters are bolded, so please consider adding \vec to the variables that are meant to be vectors.